### PR TITLE
Fix buttons logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "@pixi/sound": "^5.2.3",
     "antlr4": "^4.13.1-patch-1",
-    "pixi.js": "^7.3.3",
-    "typescript-fsm": "^1.4.5"
+    "pixi.js": "^7.3.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/src/engine/components/button.ts
+++ b/src/engine/components/button.ts
@@ -41,7 +41,7 @@ export class ButtonLogicComponent {
 
         const transitions = [
             t(State.INIT, Event.DISABLE, State.DISABLED),
-            t(State.INIT, Event.DISABLE, State.DISABLED_BUT_VISIBLE),
+            t(State.INIT, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE),
             t(State.INIT, Event.ENABLE, State.STANDARD),
 
             t(State.STANDARD, Event.OVER, State.HOVERED),

--- a/src/engine/components/button.ts
+++ b/src/engine/components/button.ts
@@ -1,22 +1,23 @@
-import {StateMachine, t} from 'typescript-fsm'
 import {DisplayObject} from 'pixi.js'
+import {StateMachine, t} from '../../stateMachine'
 
 export enum State {
-    DISABLED,
-    DISABLED_BUT_VISIBLE,
-    STANDARD,
-    HOVERED,
-    PRESSED
+    INIT = 'INIT',
+    DISABLED = 'DISABLED',
+    DISABLED_BUT_VISIBLE = 'DISABLED_BUT_VISIBLE',
+    STANDARD = 'STANDARD',
+    HOVERED = 'HOVERED',
+    PRESSED = 'PRESSED',
 }
 
 export enum Event {
-    OVER,
-    DOWN,
-    UP,
-    OUT,
-    ENABLE,
-    DISABLE,
-    DISABLE_BUT_VISIBLE
+    OVER = 'OVER',
+    DOWN = 'DOWN',
+    UP = 'UP',
+    OUT = 'OUT',
+    ENABLE = 'ENABLE',
+    DISABLE = 'DISABLE',
+    DISABLE_BUT_VISIBLE = 'DISABLE_BUT_VISIBLE',
 }
 
 type stateChangeCallback = (prevState: State, event: Event, newState: State) => void
@@ -24,62 +25,49 @@ type stateChangeCallback = (prevState: State, event: Event, newState: State) => 
 export class ButtonLogicComponent {
     private stateMachine: StateMachine<State, Event>
     private readonly onStateChangeCallback: stateChangeCallback
-    private prevState: State = State.DISABLED
 
     private readonly onMouseOverCallback
     private readonly onMouseOutCallback
     private readonly onMouseDownCallback
     private readonly onMouseUpCallback
 
-    private readonly onMouseOverCustomCallback
-    private readonly onMouseOutCustomCallback
-    private readonly onMouseDownCustomCallback
-    private readonly onMouseUpCustomCallback
-
-    constructor(
-        onStateChange: stateChangeCallback,
-        onMouseOver?: () => void,
-        onMouseOut?: () => void,
-        onMouseUp?: () => void,
-        onMouseDown?: () => void,
-    ) {
+    constructor(onStateChange: stateChangeCallback) {
         this.onStateChangeCallback = onStateChange
-        this.onMouseOverCustomCallback = onMouseOver
-        this.onMouseOutCustomCallback = onMouseOut
-        this.onMouseUpCustomCallback = onMouseUp
-        this.onMouseDownCustomCallback = onMouseDown
 
         this.onMouseOverCallback = this.onMouseOver.bind(this)
         this.onMouseOutCallback = this.onMouseOut.bind(this)
         this.onMouseDownCallback = this.onMouseDown.bind(this)
         this.onMouseUpCallback = this.onMouseUp.bind(this)
 
-        const stateCallback = this.onStateChange.bind(this)
         const transitions = [
-            t(State.STANDARD, Event.OVER, State.HOVERED, () => stateCallback(Event.OVER)),
-            t(State.HOVERED, Event.OUT, State.STANDARD, () => stateCallback(Event.OUT)),
-            t(State.HOVERED, Event.DOWN, State.PRESSED, () => stateCallback(Event.DOWN)),
-            t(State.PRESSED, Event.UP, State.HOVERED, () => stateCallback(Event.UP)),
-            t(State.PRESSED, Event.OUT, State.STANDARD, () => stateCallback(Event.OUT)),
-            t(State.DISABLED, Event.ENABLE, State.STANDARD, () => stateCallback(Event.ENABLE)),
-            t(State.DISABLED_BUT_VISIBLE, Event.ENABLE, State.STANDARD, () => stateCallback(Event.ENABLE)),
+            t(State.INIT, Event.DISABLE, State.DISABLED),
+            t(State.INIT, Event.DISABLE, State.DISABLED_BUT_VISIBLE),
+            t(State.INIT, Event.ENABLE, State.STANDARD),
 
-            t(State.STANDARD, Event.DISABLE, State.DISABLED, () => stateCallback(Event.DISABLE)),
-            t(State.HOVERED, Event.DISABLE, State.DISABLED, () => stateCallback(Event.DISABLE)),
-            t(State.PRESSED, Event.DISABLE, State.DISABLED, () => stateCallback(Event.DISABLE)),
+            t(State.STANDARD, Event.OVER, State.HOVERED),
+            t(State.STANDARD, Event.DISABLE, State.DISABLED),
+            t(State.STANDARD, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE),
 
-            t(State.STANDARD, Event.ENABLE, State.STANDARD, () => stateCallback(Event.ENABLE)),
-            t(State.DISABLED, Event.DISABLE, State.DISABLED, () => stateCallback(Event.DISABLE)),
-            t(State.DISABLED, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE, () => stateCallback(Event.DISABLE_BUT_VISIBLE)),
-            t(State.DISABLED_BUT_VISIBLE, Event.DISABLE, State.DISABLED, () => stateCallback(Event.DISABLE)),
+            t(State.HOVERED, Event.DISABLE, State.DISABLED),
+            t(State.HOVERED, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE),
+            t(State.HOVERED, Event.OUT, State.STANDARD),
+            t(State.HOVERED, Event.DOWN, State.PRESSED),
 
-            t(State.STANDARD, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE, () => stateCallback(Event.DISABLE_BUT_VISIBLE)),
-            t(State.HOVERED, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE, () => stateCallback(Event.DISABLE_BUT_VISIBLE)),
-            t(State.PRESSED, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE, () => stateCallback(Event.DISABLE_BUT_VISIBLE)),
+            t(State.PRESSED, Event.DISABLE, State.DISABLED),
+            t(State.PRESSED, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE),
+            t(State.PRESSED, Event.UP, State.HOVERED),
+            t(State.PRESSED, Event.OUT, State.STANDARD),
+
+            t(State.DISABLED, Event.ENABLE, State.STANDARD),
+            t(State.DISABLED, Event.DISABLE_BUT_VISIBLE, State.DISABLED_BUT_VISIBLE),
+
+            t(State.DISABLED_BUT_VISIBLE, Event.ENABLE, State.STANDARD),
+            t(State.DISABLED_BUT_VISIBLE, Event.DISABLE, State.DISABLED),
         ]
         this.stateMachine = new StateMachine<State, Event>(
-            State.DISABLED,
-            transitions
+            State.INIT,
+            transitions,
+            this.onStateChangeCallback,
         )
     }
 
@@ -126,56 +114,26 @@ export class ButtonLogicComponent {
     }
 
     onMouseOver() {
-        if (this.stateMachine.getState() == State.DISABLED) {
-            return
-        }
-
         if (this.stateMachine.can(Event.OVER)) {
             this.stateMachine.dispatch(Event.OVER)
         }
-
-        this.onMouseOverCustomCallback && this.onMouseOverCustomCallback()
     }
 
     onMouseUp() {
-        if (this.stateMachine.getState() == State.DISABLED) {
-            return
-        }
-
         if (this.stateMachine.can(Event.UP)) {
             this.stateMachine.dispatch(Event.UP)
         }
-
-        this.onMouseUpCustomCallback && this.onMouseUpCustomCallback()
     }
 
     onMouseOut() {
-        if (this.stateMachine.getState() == State.DISABLED) {
-            return
-        }
-
         if (this.stateMachine.can(Event.OUT)) {
             this.stateMachine.dispatch(Event.OUT)
         }
-
-        this.onMouseOutCustomCallback && this.onMouseOutCustomCallback()
     }
 
     onMouseDown() {
-        if (this.stateMachine.getState() == State.DISABLED) {
-            return
-        }
-
         if (this.stateMachine.can(Event.DOWN)) {
             this.stateMachine.dispatch(Event.DOWN)
         }
-
-        this.onMouseDownCustomCallback && this.onMouseDownCustomCallback()
-    }
-
-    onStateChange(event: Event) {
-        const state = this.stateMachine.getState()
-        this.onStateChangeCallback(this.prevState, event, state)
-        this.prevState = state
     }
 }

--- a/src/engine/types/button.ts
+++ b/src/engine/types/button.ts
@@ -81,11 +81,8 @@ export class Button extends Type<ButtonDefinition> {
             this.interactArea = new Graphics()
             this.interactArea.visible = this.definition.ENABLE
             this.engine.app.stage.addChild(this.interactArea)
-        } else {
-            this.interactArea.clear()
         }
 
-        drawRectangle(this.interactArea, rectangle, 0, 0)
         this.interactArea.hitArea = rectangle
         this.interactArea.zIndex = 9999999 - y1
     }

--- a/src/engine/types/button.ts
+++ b/src/engine/types/button.ts
@@ -1,25 +1,23 @@
 import {Type} from './index'
 import {Engine} from '../index'
 import {ButtonDefinition} from '../../fileFormats/cnv/types'
-import {createColorGraphics} from '../../utils'
+import {drawRectangle} from '../../utils'
 import {Image} from './image'
 import {Graphics, Rectangle} from 'pixi.js'
 import {ButtonLogicComponent, Event, State} from '../components/button'
 import {Animo} from './animo'
 import {AdvancedSprite} from '../rendering'
 import {assert} from '../../errors'
+import {reference} from '../../fileFormats/common'
 
 export class Button extends Type<ButtonDefinition> {
     private logic: ButtonLogicComponent
 
-    private gfxStandard?: Image | Animo
-    private gfxOnClick?: Image | Animo
-    private gfxOnMove?: Image | Animo
+    private gfxStandard: Image | Animo | null = null
+    private gfxOnClick: Image | Animo | null = null
+    private gfxOnMove: Image | Animo | null = null
 
-    private interactArea?: Graphics
-    private interactAreaDebug?: Graphics
-    private interactAreaDebugEnabled?: Graphics
-    private interactAreaDebugDisabled?: Graphics
+    private interactArea: Graphics | null = null
 
     constructor(engine: Engine, definition: ButtonDefinition) {
         super(engine, definition)
@@ -31,60 +29,28 @@ export class Button extends Type<ButtonDefinition> {
         this.callbacks.register('ONINIT', definition.ONINIT)
 
         this.logic = new ButtonLogicComponent(
-            this.onStateChange.bind(this),
-            () => this.callbacks.run('ONFOCUSON'),
-            () => this.callbacks.run('ONFOCUSOFF'),
-            () => this.callbacks.run('ONRELEASED'),
-            () => this.callbacks.run('ONCLICKED')
+            this.onStateChange.bind(this)
         )
     }
 
-    init() {}
-
-    ready() {
-        if (this.definition.RECT) {
-            let shape
-            if (Array.isArray(this.definition.RECT)) {
-                shape = this.definition.RECT
-            } else {
-                const object = this.engine.getObject(this.definition.RECT)
-                const sprite = object.getRenderObject()
-                shape = [sprite.x, sprite.y, sprite.x + sprite.width, sprite.y + sprite.height]
-            }
-
-            const [x1, y1, x2, y2] = shape
-            const rect = new Rectangle(x1, y1, x2-x1, y2-y1)
-            this.interactArea = createColorGraphics(rect, 0, 0)
-            this.interactArea.hitArea = rect
-            this.interactArea.zIndex = 9999999 - y1
-            this.interactArea.visible = this.definition.ENABLE
-
-            if (this.engine.debug) {
-                this.interactAreaDebugEnabled = createColorGraphics(rect, 0, 0, 3, 0x00ff00)
-                this.interactAreaDebugEnabled.zIndex = 99999999
-                this.interactAreaDebug = this.logic.getState() != State.DISABLED ? this.interactAreaDebugEnabled : this.interactAreaDebugDisabled
-
-                this.interactAreaDebugDisabled = createColorGraphics(rect, 0, 0, 3, 0xff0000)
-                this.interactAreaDebugDisabled.zIndex = 99999999
-            }
-        }
-
-        if (this.interactArea) {
-            this.engine.app.stage.addChild(this.interactArea)
-        }
-        if (this.interactAreaDebug) {
-            this.engine.app.stage.addChild(this.interactAreaDebug)
-        }
-
-        // This has to be in ready() because it references other objects assigned in init()...
+    init() {
         if (this.definition.GFXSTANDARD) {
             this.gfxStandard = this.engine.getObject(this.definition.GFXSTANDARD)
+            assert(this.gfxStandard !== null, 'the GFXSTANDARD object should exist')
         }
         if (this.definition.GFXONCLICK) {
             this.gfxOnClick = this.engine.getObject(this.definition.GFXONCLICK)
+            assert(this.gfxOnClick !== null, 'the GFXONCLICK object should exist')
         }
         if (this.definition.GFXONMOVE) {
             this.gfxOnMove = this.engine.getObject(this.definition.GFXONMOVE)
+            assert(this.gfxOnMove !== null, 'the GFXONMOVE object should exist')
+        }
+    }
+
+    ready() {
+        if (this.definition.RECT) {
+            this.setRect(this.definition.RECT)
         }
 
         if (this.definition.ENABLE) {
@@ -93,23 +59,43 @@ export class Button extends Type<ButtonDefinition> {
             this.logic.disable()
         }
 
-        // ...including ONINIT
         this.callbacks.run('ONINIT')
+    }
+
+    private setRect(rect: number[] | reference) {
+        let shape
+        if (Array.isArray(rect)) {
+            shape = rect
+        } else {
+            const object = this.engine.getObject(rect)
+            assert(object !== null, 'object referred by RECT should exist')
+
+            const sprite = object.getRenderObject()
+            shape = [sprite.x, sprite.y, sprite.x + sprite.width, sprite.y + sprite.height]
+        }
+
+        const [x1, y1, x2, y2] = shape
+        const rectangle = new Rectangle(x1, y1, x2-x1, y2-y1)
+
+        if (this.interactArea === null) {
+            this.interactArea = new Graphics()
+            this.interactArea.visible = this.definition.ENABLE
+            this.engine.app.stage.addChild(this.interactArea)
+        } else {
+            this.interactArea.clear()
+        }
+
+        drawRectangle(this.interactArea, rectangle, 0, 0)
+        this.interactArea.hitArea = rectangle
+        this.interactArea.zIndex = 9999999 - y1
     }
 
     destroy() {
         if (this.interactArea) {
             this.logic.unregisterInteractive(this.interactArea)
             this.engine.app.stage.removeChild(this.interactArea)
-        }
-        if (this.interactAreaDebug) {
-            this.engine.app.stage.removeChild(this.interactAreaDebug)
-        }
-
-        if (!this.interactArea) {
-            if (this.gfxStandard) {
-                this.unregisterInteractive(this.gfxStandard)
-            }
+        } else if (this.gfxStandard) {
+            this.unregisterInteractive(this.gfxStandard)
         }
     }
 
@@ -118,18 +104,6 @@ export class Button extends Type<ButtonDefinition> {
             // For area button
             this.interactArea.visible = state != State.DISABLED
             this.interactArea.interactive = state != State.DISABLED
-
-            if (this.engine.debug) {
-                if (state == State.DISABLED) {
-                    this.engine.app.stage.removeChild(this.interactAreaDebug!)
-                    this.interactAreaDebug = this.interactAreaDebugDisabled
-                    this.engine.app.stage.addChild(this.interactAreaDebug!)
-                } else {
-                    this.engine.app.stage.removeChild(this.interactAreaDebug!)
-                    this.interactAreaDebug = this.interactAreaDebugEnabled
-                    this.engine.app.stage.addChild(this.interactAreaDebug!)
-                }
-            }
         }
 
         if (state == State.DISABLED) {
@@ -173,6 +147,14 @@ export class Button extends Type<ButtonDefinition> {
             if (this.interactArea) {
                 this.logic.unregisterInteractive(this.interactArea)
             }
+        } else if (event == Event.DOWN) {
+            this.callbacks.run('ONCLICKED')
+        } else if (event == Event.UP) {
+            this.callbacks.run('ONRELEASED')
+        } else if (event == Event.OVER) {
+            this.callbacks.run('ONFOCUSON')
+        } else if (event == Event.OUT) {
+            this.callbacks.run('ONFOCUSOFF')
         }
     }
 
@@ -192,6 +174,10 @@ export class Button extends Type<ButtonDefinition> {
         this.gfxStandard?.SETPRIORITY(priority)
         this.gfxOnMove?.SETPRIORITY(priority)
         this.gfxOnClick?.SETPRIORITY(priority)
+    }
+
+    SETRECT(objectName: string) {
+        this.setRect({ objectName })
     }
 
     registerInteractive(object: Image | Animo) {
@@ -220,7 +206,7 @@ export class Button extends Type<ButtonDefinition> {
         }
     }
 
-    private setSpriteAlpha(object: Image | Animo | undefined, alpha: number) {
+    private setSpriteAlpha(object: Image | Animo | null, alpha: number) {
         if (object) {
             const renderObject = object.getRenderObject()
             if (renderObject) {

--- a/src/stateMachine.ts
+++ b/src/stateMachine.ts
@@ -1,0 +1,50 @@
+export interface Transition<STATE, EVENT> {
+    from: STATE
+    event: EVENT
+    to: STATE
+}
+
+export type Callback<STATE extends number | string, EVENT extends number | string> = (previousState: STATE, event: EVENT, newState: STATE) => void;
+
+export class StateMachine<STATE extends number | string, EVENT extends number | string> {
+    private currentState: STATE
+    private readonly onStateChange: Callback<STATE, EVENT>
+
+    constructor(initialState: STATE, protected transitions: Transition<STATE, EVENT>[] = [], onStateChange: Callback<STATE, EVENT>) {
+        this.currentState = initialState
+        this.onStateChange = onStateChange
+    }
+
+    getState() {
+        return this.currentState
+    }
+
+    can(event: EVENT): boolean {
+        return this.transitions.some(
+            transition => transition.from === this.currentState && transition.event === event
+        )
+    }
+
+    dispatch(event: EVENT) {
+        const transition = this.transitions.find(
+            transition => transition.from === this.currentState && transition.event === event
+        )
+
+        if (transition === undefined) {
+            throw new Error('No transition found for event from current state')
+        }
+
+        const previousState = this.currentState
+        this.currentState = transition.to
+
+        this.onStateChange(previousState, event, this.currentState)
+    }
+}
+
+export function t<STATE extends number | string, EVENT extends number | string>(from: STATE, event: EVENT, to: STATE): Transition<STATE, EVENT> {
+    return {
+        from,
+        event,
+        to,
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import {Application, Graphics, Sprite, Rectangle} from 'pixi.js'
+import {Application, Graphics, Rectangle} from 'pixi.js'
 
 export const pathJoin = (...parts: Array<string>) => {
     const fixedParts = parts.map(part => part.replace(/\\/g, '/'))
@@ -9,23 +9,16 @@ export const stringUntilNull = (text: string) => {
     return text.substring(0, text.indexOf('\x00'))
 }
 
-export const createColorGraphics = (dimensions: Rectangle, color: number, alpha?: number, borderWidth?: number, borderColor?: number) => {
-    const graphics = new Graphics()
+export const drawRectangle = (graphics: Graphics, dimensions: Rectangle, color: number, alpha?: number, borderWidth?: number, borderColor?: number) => {
     graphics.beginFill(color, alpha)
     if (borderWidth !== undefined && borderWidth > 0) {
         graphics.lineStyle(borderWidth, borderColor ?? 0xffa500)
     }
     graphics.drawRect(dimensions.x, dimensions.y, dimensions.width, dimensions.height)
-    return graphics
 }
 
 export const createColorTexture = (app: Application, dimensions: Rectangle, color: number, alpha?: number) => {
-    const graphics = createColorGraphics(dimensions, color, alpha)
+    const graphics = new Graphics()
+    drawRectangle(graphics, dimensions, color, alpha)
     return app.renderer.generateTexture(graphics)
-}
-
-export const createColorSprite = (app: Application, dimensions: Rectangle, color: number, alpha?: number) => {
-    const background = new Sprite(createColorTexture(app, dimensions, color, alpha))
-    background.zIndex = -99999
-    return background
 }


### PR DESCRIPTION
Now it is more predictable and stable. 

- Button starts with the INIT state and have to be enabled/disabled by either definition or manual ENABLE()/DISABLE() call.
- Moving triggering callbacks to onStateChange instead of using "custom mouse callbacks" fixed sound playing twice in MAINMENU in Ufo
- I removed debug green/red rectangles, so that we implement it more globally for multiple types of objects.
- State machine library is replaced with own state machine implementation
- I added SETRECT to ease the merging
