### PR TITLE
Implement IMAGE^SETOPACITY

### DIFF
--- a/src/engine/types/image.ts
+++ b/src/engine/types/image.ts
@@ -36,7 +36,8 @@ export class Image extends DisplayType<ImageDefinition> {
 
     @method()
     SETOPACITY(opacity: number) {
-        throw new NotImplementedError()
+        assert(this.sprite !== null)
+        this.sprite.alpha = opacity / 255.
     }
 
     @method()


### PR DESCRIPTION
In the original game, only the first call to `IMGBLANK^SETOPACITY(VAROPACITY);` actually changes the opacity of IMGBLANK. For any further call to work, the image needs to be invalidated in some way (e.g. by calling `IMGBLANK^INVALIDATE();`, `IMGBLANK^HIDE();IMGBLANK^SHOW();`, `IMGBLANK^MOVE(0,0);`, or `IMGBLANK^SETPOSITION(0,0);`).